### PR TITLE
RPi-AB-Case: fix module include filename

### DIFF
--- a/RPi-AB-Case/RPi AB Case - MiniDexed HD44780.scad
+++ b/RPi-AB-Case/RPi AB Case - MiniDexed HD44780.scad
@@ -123,5 +123,5 @@ if (show_base) {
 // Main RPI SCAD definitions
 //
 ////////////////////////////////////////////////////////////////////
-include <RPIABCaseModule.scad>
+include <RPiABCaseModule.scad>
 

--- a/RPi-AB-Case/RPi AB Case - MiniDexed SSD1306.scad
+++ b/RPi-AB-Case/RPi AB Case - MiniDexed SSD1306.scad
@@ -109,5 +109,5 @@ md_ext = [0,0,15];
 // Main RPI SCAD definitions
 //
 ////////////////////////////////////////////////////////////////////
-include <RPIABCaseModule.scad>
+include <RPiABCaseModule.scad>
 


### PR DESCRIPTION
use case-sensitive filenames to work on case-sensitive filesystems